### PR TITLE
Renamed intermediate output file with substring "dkt_majority_affine"…

### DIFF
--- a/bin/MCRIBTissueSegMCRIBS
+++ b/bin/MCRIBTissueSegMCRIBS
@@ -361,7 +361,7 @@ then
 		--transform $TEMPLATEDIR/ALBERTsTemplate40ToTemplate1InverseWarp.nii.gz \
 		--output-data-type short \
 		--interpolation GenericLabel \
-		--output ${OUTPUTPREFIX}_majority_dkt_affine_reg.nii.gz
+		--output ${OUTPUTPREFIX}_dkt_majority_affine_reg.nii.gz
 	antsApplyTransforms -v -d 3 --input $TEMPLATEDIR/template-40_brain_mask_hull_added.nii.gz --reference-image ${OUTPUTPREFIX}_t2w_restore_brain.nii.gz \
 		--transform [${OUTPUTPREFIX}_alberts_to_native_affine_reg0GenericAffine.mat,0] \
 		--output-data-type short \


### PR DESCRIPTION
… instead of "majority_dkt_affine"

See [issue 16](https://github.com/DevelopmentalImagingMCRI/MCRIBS/issues/16)