### PR TITLE
Reset variable "strnum" in second loop

### DIFF
--- a/bin/MCRIBTissueSegMCRIBS
+++ b/bin/MCRIBTissueSegMCRIBS
@@ -555,6 +555,7 @@ if [ ! -f "${OUTPUTPREFIX}_drawem_alberts_tissueseg.nii.gz" ]
 then
 	emsstructures=
 	structures="csf gm wm outlier ventricles cerebstem dgm hwm lwm"
+	strnum=0
 	for str in ${structures}
 	do
 		strnum=$(($strnum+1))
@@ -607,6 +608,7 @@ MakeKMeans34Class $SUBJID
 
 emsstructures=
 structures="csf gm wm outlier ventricles cerebstem dgm hwm lwm"
+strnum=0
 for str in ${structures}
 do
 	strnum=$(($strnum+1))


### PR DESCRIPTION
This script also caused an error when a "strnum" variable is not reset; in the second, very similar loop, the same "strnum" variable tried to read MIRTK DrawEM templates 10-18 which don't exist